### PR TITLE
[GB] Removes unnecessary inline CSS and adds a CSS class.

### DIFF
--- a/paper.js
+++ b/paper.js
@@ -1,12 +1,11 @@
 function newPaper(diameter, color) {
   var container = document.createElement('div')
-  container.style.borderRadius = '50px'
+  container.className = 'identicon'
+  container.style.borderRadius = '50%'
   container.style.overflow = 'hidden'
-  container.style.padding = '0px'
-  container.style.margin = '0px'
   container.style.width = '' + diameter + 'px'
   container.style.height = '' + diameter + 'px'
-  container.style.display = 'inline-block'
+  container.style.display = 'block'
   container.style.background = color
   return {
     container: container,


### PR DESCRIPTION
A few suggested improvements.

Add a CSS class of identicon. Could also be "jazzicon" if preferred? This enables overriding of any of the inline CSS.

Border radius to 50%, so it auto matches the width and height. Right now, 50px would be too small if my width / height > 100.

Display: block, because inline-block adds space under the element, messing with positioning.

Remove padding and margin 0 as no browser applies these by default anyway.